### PR TITLE
Adds MacOS support

### DIFF
--- a/wikis/wiki-update.sh
+++ b/wikis/wiki-update.sh
@@ -3,8 +3,19 @@
 cd $(dirname $0)
 
 IFS=$'\n'
-files=$(find "$(pwd -P)" -type f -name "*.md" -printf '"%p"\n' | sort)
 TARGET=../webs/wikis.js
+
+# os detection for linux vs macos (bsd vs gnu find)
+find_base="find \"$(pwd -P)\" -type f -name \"*md\" -print"
+find_linux="f '\"%p\"\n'"
+find_macos="0 | xargs -0 stat -f '%N'"
+case $(uname -s) in
+    Linux*)     find_cmd="$find_base$find_linux | sort";;
+    Darwin*)    find_cmd="$find_base$find_macos | sort";;
+    *)          echo "os not supported...(yet)";exit -1;;
+esac
+
+files=$(eval $find_cmd)
 
 echo "var wikiLists = [" > $TARGET
 for f in $files


### PR DESCRIPTION
MacOS ships with BSD `find`, not GNU `find`, so the `-printf` option is unavailable. I mitigated this by checking if the OS is Linux or MacOS, and running the correctly structured command.

This _probably_ could be adapted to support other *nix environments, like BSD or Cygwin.